### PR TITLE
ReStock+ and stock config fixes

### DIFF
--- a/GameData/RealFuels-Stock/Restock/Size2LFB_Twin-Boar.cfg
+++ b/GameData/RealFuels-Stock/Restock/Size2LFB_Twin-Boar.cfg
@@ -9,50 +9,50 @@
 
 @PART[Size2LFB]:NEEDS[ReStock,SmokeScreen]:FOR[RealPlume] 
 {
-	PLUME
-	{
-		name = Kerolox_LowerFlame
-		transformName = fxTransformPlume
-		localRotation = 90,0,0
-		localPosition = 0,0,0
-		emissionMult = 1
-		speed = 1
-		energy = 1
-		plumePosition = 0,1,0
-		plumeScale = 1.7
-		flamePosition = 0,1,0
-		flameScale = 1.8
-		flarePosition = 0,1.5,0
-		flareScale = 0.1      
-	}
-	PLUME
-	{
-      name = Cryogenic_LowerSSME_CE
-      transformName = thrustTransform
-      localRotation = 0,0,0
-      localPosition = 0,0,0
-      speed = 1
-      energy = 1
-      emissionMult = 1
-      shockPosition = 0,0,0
-      shockScale = 0.4
-      plumePosition = 0,0,-0.2
-      plumeScale = 1.2
-	}
-	@MODULE[ModuleEngines*]
-	{
-		@name = ModuleEnginesRF
-	}
-	@MODULE[ModuleEngineConfigs]
-	{
-		@type = ModuleEnginesRF
-		@CONFIG[Kerosene+LqdOxygen]
-		{
-			%powerEffectName = Kerolox_LowerFlame
-		}
-		@CONFIG[LqdHydrogen+LqdOxygen]
-		{
-			%powerEffectName = Cryogenic_LowerSSME_CE
-		}
-	}
+  PLUME
+  {
+    name = Kerolox_LowerFlame
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,1,0
+    emissionMult = 1
+    speed = 1
+    energy = 1
+    plumePosition = 0,-2,-0.5
+    plumeScale = 0.3
+    flamePosition = 0,-2,-0.4
+    flameScale = 1
+    flarePosition = 0,-2,-0.7
+    flareScale = 0.06      
+  }
+  PLUME
+  {
+    name = Cryogenic_LowerSSME_CE
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+    speed = 1
+    energy = 1
+    emissionMult = 1
+    shockPosition = 0,-2,-0.5
+    shockScale = 0.4
+    plumePosition = 0,-2,-0.5
+    plumeScale = 1.2
+  }
+  @MODULE[ModuleEngines*]
+  {
+    @name = ModuleEnginesRF
+  }
+  @MODULE[ModuleEngineConfigs]
+  {
+    @type = ModuleEnginesRF
+    @CONFIG[Kerosene+LqdOxygen]
+    {
+      %powerEffectName = Kerolox_LowerFlame
+    }
+    @CONFIG[LqdHydrogen+LqdOxygen]
+    {
+      %powerEffectName = Cryogenic_LowerSSME_CE
+    }
+  }
 }

--- a/GameData/RealFuels-Stock/RestockPlus/restock-engine-boar.cfg
+++ b/GameData/RealFuels-Stock/RestockPlus/restock-engine-boar.cfg
@@ -5,7 +5,7 @@
 @PART[restock-engine-boar]:FOR[RealFuels_StockEngines] 
 {
 
-  @mass = 1.1
+  @mass = 1.6
   @cost = 3139
   %entryCost = 15695
   @maxTemp = 2375
@@ -18,28 +18,28 @@
     @heatProduction = 181
     @atmosphereCurve
     {
-      key = 0 300
-      key = 1 280
-      key = 12 100
+      @key,0 = 0 335
+      @key,1 = 1 302
+      @key,12 = 12 100
     }
     !PROPELLANT[LiquidFuel] {}
     !PROPELLANT[Oxidizer] {}
     !PROPELLANT[MonoPropellant] {}
     PROPELLANT
     {
-      name = Kerosene
-      ratio = 35.756816
-      DrawGauge = True
-      %resourceFlowMode = STACK_PRIORITY_SEARCH
+        name = LqdHydrogen
+        ratio = 74.54227709997224
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
-      name = LqdOxygen
-      ratio = 64.243184
-      %resourceFlowMode = STACK_PRIORITY_SEARCH
+        name = LqdOxygen
+        ratio = 25.45772290002776
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
   }
-  
+
   MODULE
   {
     name = ModuleEngineConfigs
@@ -47,9 +47,40 @@
     techLevel = 6
     origTechLevel = 6
     engineType = L
-    origMass = 1.1
-    configuration = Kerosene+LqdOxygen
+    origMass = 1.6
+    configuration = LqdHydrogen+LqdOxygen
     modded = false
+
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 1000
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 74.54227709997224
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 25.45772290002776
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.3000
+      IspV = 1.2700
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 10
+      }
+    }
 
     CONFIG
     {
@@ -59,14 +90,14 @@
       PROPELLANT
       {
         name = Kerosene
-        ratio = 35.75681604512692
+        ratio = 37.69408655434424
         DrawGauge = True
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = LqdOxygen
-        ratio = 64.24318395487307
+        ratio = 62.30591344565576
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 1.0000
@@ -80,9 +111,8 @@
         name = ElectricCharge
         amount = 10
       }
-      
-      
     }
+
   }
   ignitions = 1
   ullage = true
@@ -118,6 +148,21 @@
 		flarePosition = 0,1.5,0
 		flareScale = 0.1
 	}
+  PLUME
+	{
+    name = Cryogenic_LowerSSME_CE
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0
+		emissionMult = 1
+		speed = 1
+		energy = 1
+    emissionMult = 1
+    shockPosition = 0,0,0
+    shockScale = 0.4
+    plumePosition = 0,0,0
+    plumeScale = 1.2  
+	}
 	@MODULE[ModuleEngines*]
 	{
 		@name = ModuleEnginesRF
@@ -125,23 +170,13 @@
 	@MODULE[ModuleEngineConfigs]
 	{
 		@type = ModuleEnginesRF
-		@CONFIG,*
+		@CONFIG[Kerosene+LqdOxygen]
 		{
 			%powerEffectName = Kerolox_LowerFlame
 		}
-	}
-}
-
-@PART[Size2LFB]:AFTER[zzRealPlume]:NEEDS[ReStock]
-{
-  @EFFECTS
-  {
-    @Kerolox_LowerFlame
+		@CONFIG[LqdHydrogen+LqdOxygen]
 		{
-			@MODEL_MULTI_SHURIKEN_PERSIST[*],*
-			{
-				offsetDirection = 0,1,0
-			}
+			%powerEffectName = Cryogenic_LowerSSME_CE
 		}
-  }
+	}
 }

--- a/GameData/RealFuels-Stock/RestockPlus/restock-engine-caravel-1.cfg
+++ b/GameData/RealFuels-Stock/RestockPlus/restock-engine-caravel-1.cfg
@@ -27,14 +27,14 @@
     PROPELLANT
     {
       name = LqdHydrogen
-      ratio = 73.858542
+      ratio = 76.30830964721619
       DrawGauge = True
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
       name = LqdOxygen
-      ratio = 26.141458
+      ratio = 23.69169035278381
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
   }
@@ -58,14 +58,14 @@
       PROPELLANT
       {
         name = LqdHydrogen
-        ratio = 73.85854244276935
+        ratio = 74.54227709997224
         DrawGauge = True
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = LqdOxygen
-        ratio = 26.141457557230652
+        ratio = 25.45772290002776
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 1.3000

--- a/GameData/RealFuels-Stock/RestockPlus/restock-engine-cherenkov.cfg
+++ b/GameData/RealFuels-Stock/RestockPlus/restock-engine-cherenkov.cfg
@@ -2,10 +2,10 @@
 // REAL FUELS // 
 // ---------- //
 
-@PART[restock-engine-cherenkov]:FOR[RealFuels_StockEngines] //Blank Engine
+@PART[restock-engine-cherenkov]:FOR[RealFuels_StockEngines]
 {
 
-  @mass = 4
+  @mass = 12.9
   @cost = 97857
   %entryCost = 489285
   @maxTemp = 2400
@@ -40,13 +40,13 @@
     techLevel = 6
     origTechLevel = 6
     engineType = N
-    origMass = 4
-    configuration = LqdHydrogen
+    origMass = 12.9
+    configuration = NTRLqdHydrogen
     modded = false
 
     CONFIG
     {
-      name = LqdHydrogen
+      name = NTRLqdHydrogen
       maxThrust = 248
       heatProduction = 409
       PROPELLANT
@@ -61,22 +61,84 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 1.3000
-      IspV = 1.2700
+      IspSL = 1.0000
+      IspV = 1.0000
       throttle = 0
-      ignitions = 1
+      ignitions = 0
       ullage = true
       pressureFed = false
       IGNITOR_RESOURCE
       {
         name = ElectricCharge
-        amount = 3.3
+        amount = 0.6
       }
-      
-      
+
+
+    }
+    CONFIG
+    {
+      name = NTRLqdAmmonia
+      maxThrust = 380
+      heatProduction = 409
+      PROPELLANT
+      {
+        name = LqdAmmonia
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.5331
+      IspV = 0.5331
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.6
+      }
+
+
+    }
+    CONFIG
+    {
+      name = NTRLqdMethane
+      maxThrust = 417
+      heatProduction = 409
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.6689
+      IspV = 0.6689
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.6
+      }
+
+
     }
   }
-  ignitions = 1
+  ignitions = 0
   ullage = true
   pressureFed = false
   IGNITOR_RESOURCE

--- a/GameData/RealFuels-Stock/RestockPlus/restock-engine-corgi.cfg
+++ b/GameData/RealFuels-Stock/RestockPlus/restock-engine-corgi.cfg
@@ -28,15 +28,15 @@
     PROPELLANT
     {
       name = LqdHydrogen
-      ratio = 90.451823
+      ratio = 74.54227709997224
       DrawGauge = True
-      %resourceFlowMode = STAGE_PRIORITY_FLOW
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
       name = LqdOxygen
-      ratio = 9.548177
-      %resourceFlowMode = STAGE_PRIORITY_FLOW
+      ratio = 25.45772290002776
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
   }
   
@@ -59,15 +59,15 @@
       PROPELLANT
       {
         name = LqdHydrogen
-        ratio = 84
+        ratio = 76.30830964721619
         DrawGauge = True
-        %resourceFlowMode = STAGE_PRIORITY_FLOW
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = LqdOxygen
-        ratio = 16
-        %resourceFlowMode = STAGE_PRIORITY_FLOW
+        ratio = 23.69169035278381
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 0.0900
       IspV = 1.2700

--- a/GameData/RealFuels-Stock/RestockPlus/restock-engine-pug.cfg
+++ b/GameData/RealFuels-Stock/RestockPlus/restock-engine-pug.cfg
@@ -27,14 +27,14 @@
     PROPELLANT
     {
       name = Aerozine50
-      ratio = 45
+      ratio = 50.173010
       DrawGauge = True
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
       name = NTO
-      ratio = 55
+      ratio = 49.826990
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
   }
@@ -58,14 +58,14 @@
       PROPELLANT
       {
         name = Aerozine50
-        ratio = 45
+        ratio = 50.173010
         DrawGauge = True
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = NTO
-        ratio = 55
+        ratio = 49.826990
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 0.0900

--- a/GameData/RealFuels-Stock/RestockPlus/restock-engine-schnauzer-1.cfg
+++ b/GameData/RealFuels-Stock/RestockPlus/restock-engine-schnauzer-1.cfg
@@ -27,14 +27,14 @@
     PROPELLANT
     {
       name = Aerozine50
-      ratio = 41.193182
+      ratio = 50.173010
       DrawGauge = True
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
       name = NTO
-      ratio = 58.806818
+      ratio = 49.826990
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
   }
@@ -58,14 +58,14 @@
       PROPELLANT
       {
         name = Aerozine50
-        ratio = 41.19318181818182
+        ratio = 50.173010
         DrawGauge = True
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = NTO
-        ratio = 58.80681818181818
+        ratio = 49.826990
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 0.9600

--- a/GameData/RealFuels-Stock/RestockPlus/restock-engine-torch.cfg
+++ b/GameData/RealFuels-Stock/RestockPlus/restock-engine-torch.cfg
@@ -28,15 +28,15 @@
     PROPELLANT
     {
       name = Kerosene
-      ratio = 60.198375
+      ratio = 37.69408655434424
       DrawGauge = True
-      %resourceFlowMode = STAGE_PRIORITY_FLOW
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
       name = LqdOxygen
-      ratio = 39.801625
-      %resourceFlowMode = STAGE_PRIORITY_FLOW
+      ratio = 62.30591344565576
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
   }
   
@@ -59,15 +59,15 @@
       PROPELLANT
       {
         name = Kerosene
-        ratio = 60.19837501318982
+        ratio = 37.69408655434424
         DrawGauge = True
-        %resourceFlowMode = STAGE_PRIORITY_FLOW
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = LqdOxygen
-        ratio = 39.80162498681018
-        %resourceFlowMode = STAGE_PRIORITY_FLOW
+        ratio = 62.30591344565576
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 1.0000
       IspV = 1.0000

--- a/GameData/RealFuels-Stock/RestockPlus/restock-engine-valiant.cfg
+++ b/GameData/RealFuels-Stock/RestockPlus/restock-engine-valiant.cfg
@@ -27,15 +27,15 @@
     PROPELLANT
     {
       name = Kerosene
-      ratio = 45.302946
+      ratio = 37.69408655434424
       DrawGauge = True
-      %resourceFlowMode = STAGE_PRIORITY_FLOW
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
       name = LqdOxygen
-      ratio = 54.697054
-      %resourceFlowMode = STAGE_PRIORITY_FLOW
+      ratio = 62.30591344565576
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
   }
   

--- a/GameData/RealFuels-Stock/RestockPlus/restock-rcs.cfg
+++ b/GameData/RealFuels-Stock/RestockPlus/restock-rcs.cfg
@@ -1,0 +1,546 @@
+// Patch for ReStock+ RCS thrusters to have same configurability as stock
+
+// RC-1x series (250 N base thrust)
+@PART[restock-rcs-*-mini-1]:FOR[RealFuels_StockEngines]:NEEDS[ReStockPlus]
+{
+  @mass *= 0.8
+
+  @MODULE[ModuleRCS*]
+  {
+    @thrusterPower = 0.145
+    !resourceName = DELETE
+    @atmosphereCurve
+    {
+      @key,0 = 0 281
+      @key,1 = 1 101
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Hydrazine
+      ratio = 100
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleRCS
+    techLevel = 1
+    origTechLevel = 1
+    engineType = L
+    origMass = #$../mass$
+    configuration = Hydrazine
+    modded = false
+    CONFIG
+    {
+      name = MMH+NTO
+      thrusterPower = 0.25
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 0.51135562
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.48864438
+      }
+      IspSL = 0.4
+      IspV = 0.952
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      thrusterPower = 0.145
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 1
+      }
+      IspSL = 0.23
+      IspV = 0.72
+    }
+    CONFIG
+    {
+      name = HTP
+      thrusterPower = 0.060
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 1
+      }
+      IspSL = 0.2
+      IspV = 0.465
+    }
+    CONFIG
+    {
+      name = Nitrogen
+      thrusterPower = 0.056
+      PROPELLANT
+      {
+        name = Nitrogen
+        ratio = 1
+      }
+      IspSL = 0.1
+      IspV = 0.195
+    }
+    CONFIG
+    {
+      name = NitrousOxide
+      thrusterPower = 0.056
+      PROPELLANT
+      {
+        name = NitrousOxide
+        ratio = 1
+      }
+      IspSL = 0.253
+      IspV = 0.5
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      thrusterPower = 0.248
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 0.47823219
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.52176781
+      }
+      IspSL = 0.396
+      IspV = 0.943
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      thrusterPower = 0.25
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 0.48657718
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.51342282
+      }
+      IspSL = 0.403
+      IspV = 0.955
+    }
+  }
+}
+
+// RV-10x series (1 kN base thrust)
+// RV-102
+@PART[restock-rcs-block-dual-1]:FOR[RealFuels_StockEngines]:NEEDS[ReStockPlus]
+{
+  @mass *= 0.8
+
+  @MODULE[ModuleRCS*]
+  {
+    @thrusterPower = 0.578
+    !resourceName = DELETE
+    @atmosphereCurve
+    {
+      @key,0 = 0 281
+      @key,1 = 1 101
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Hydrazine
+      ratio = 100
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleRCS
+    techLevel = 1
+    origTechLevel = 1
+    engineType = L
+    origMass = #$../mass$
+    configuration = Hydrazine
+    modded = false
+    CONFIG
+    {
+      name = MMH+NTO
+      thrusterPower = 1
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 0.51135562
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.48864438
+      }
+      IspSL = 0.4
+      IspV = 0.952
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      thrusterPower = 0.578
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 1
+      }
+      IspSL = 0.23
+      IspV = 0.72
+    }
+    CONFIG
+    {
+      name = HTP
+      thrusterPower = 0.241
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 1
+      }
+      IspSL = 0.2
+      IspV = 0.465
+    }
+    CONFIG
+    {
+      name = Nitrogen
+      thrusterPower = 0.225
+      PROPELLANT
+      {
+        name = Nitrogen
+        ratio = 1
+      }
+      IspSL = 0.1
+      IspV = 0.195
+    }
+    CONFIG
+    {
+      name = NitrousOxide
+      thrusterPower = 0.225
+      PROPELLANT
+      {
+        name = NitrousOxide
+        ratio = 1
+      }
+      IspSL = 0.253
+      IspV = 0.5
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      thrusterPower = 0.993
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 0.47823219
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.52176781
+      }
+      IspSL = 0.396
+      IspV = 0.943
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      thrusterPower = 1
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 0.48657718
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.51342282
+      }
+      IspSL = 0.403
+      IspV = 0.955
+    }
+  }
+}
+
+// RV-103/5-A
+@PART[restock-rcs-block-*-angled-1]:FOR[RealFuels_StockEngines]:NEEDS[ReStockPlus]
+{
+  @mass *= 0.8
+
+  @MODULE[ModuleRCS*]
+  {
+    @thrusterPower = 0.578
+    !resourceName = DELETE
+    @atmosphereCurve
+    {
+      @key,0 = 0 281
+      @key,1 = 1 101
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Hydrazine
+      ratio = 100
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleRCS
+    techLevel = 1
+    origTechLevel = 1
+    engineType = L
+    origMass = #$../mass$
+    configuration = Hydrazine
+    modded = false
+    CONFIG
+    {
+      name = MMH+NTO
+      thrusterPower = 1
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 0.51135562
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.48864438
+      }
+      IspSL = 0.4
+      IspV = 0.952
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      thrusterPower = 0.578
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 1
+      }
+      IspSL = 0.23
+      IspV = 0.72
+    }
+    CONFIG
+    {
+      name = HTP
+      thrusterPower = 0.241
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 1
+      }
+      IspSL = 0.2
+      IspV = 0.465
+    }
+    CONFIG
+    {
+      name = Nitrogen
+      thrusterPower = 0.225
+      PROPELLANT
+      {
+        name = Nitrogen
+        ratio = 1
+      }
+      IspSL = 0.1
+      IspV = 0.195
+    }
+    CONFIG
+    {
+      name = NitrousOxide
+      thrusterPower = 0.225
+      PROPELLANT
+      {
+        name = NitrousOxide
+        ratio = 1
+      }
+      IspSL = 0.253
+      IspV = 0.5
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      thrusterPower = 0.993
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 0.47823219
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.52176781
+      }
+      IspSL = 0.396
+      IspV = 0.943
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      thrusterPower = 1
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 0.48657718
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.51342282
+      }
+      IspSL = 0.403
+      IspV = 0.955
+    }
+  }
+}
+
+// RV-105-X
+@PART[restock-rcs-block-quint-1]:FOR[RealFuels_StockEngines]:NEEDS[ReStockPlus]
+{
+  @mass *= 0.8
+
+  @MODULE[ModuleRCS*]
+  {
+    @thrusterPower = 0.578
+    !resourceName = DELETE
+    @atmosphereCurve
+    {
+      @key,0 = 0 281
+      @key,1 = 1 101
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Hydrazine
+      ratio = 100
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleRCS
+    techLevel = 1
+    origTechLevel = 1
+    engineType = L
+    origMass = #$../mass$
+    configuration = Hydrazine
+    modded = false
+    CONFIG
+    {
+      name = MMH+NTO
+      thrusterPower = 1
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 0.51135562
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.48864438
+      }
+      IspSL = 0.4
+      IspV = 0.952
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      thrusterPower = 0.578
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 1
+      }
+      IspSL = 0.23
+      IspV = 0.72
+    }
+    CONFIG
+    {
+      name = HTP
+      thrusterPower = 0.241
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 1
+      }
+      IspSL = 0.2
+      IspV = 0.465
+    }
+    CONFIG
+    {
+      name = Nitrogen
+      thrusterPower = 0.225
+      PROPELLANT
+      {
+        name = Nitrogen
+        ratio = 1
+      }
+      IspSL = 0.1
+      IspV = 0.195
+    }
+    CONFIG
+    {
+      name = NitrousOxide
+      thrusterPower = 0.225
+      PROPELLANT
+      {
+        name = NitrousOxide
+        ratio = 1
+      }
+      IspSL = 0.253
+      IspV = 0.5
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      thrusterPower = 0.993
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 0.47823219
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.52176781
+      }
+      IspSL = 0.396
+      IspV = 0.943
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      thrusterPower = 1
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 0.48657718
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.51342282
+      }
+      IspSL = 0.403
+      IspV = 0.955
+    }
+  }
+}

--- a/GameData/RealFuels-Stock/Squad/squad_rcs.cfg
+++ b/GameData/RealFuels-Stock/Squad/squad_rcs.cfg
@@ -5,167 +5,178 @@
 
 @PART[RCSBlock_v2]:FOR[RealFuels_StockEngines]
 {
- @mass = 0.029
+  @mass = 0.029
 
- @MODULE[ModuleRCS*]
- {
-  @thrusterPower = 0.578
-  !resourceName = DELETE
-  @atmosphereCurve
+  @MODULE[ModuleRCS*]
   {
-   @key,0 = 0 281
-   @key,1 = 1 101
+    @thrusterPower = 0.578
+    !resourceName = DELETE
+    @atmosphereCurve
+    {
+      @key,0 = 0 281
+      @key,1 = 1 101
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Hydrazine
+      ratio = 100
+    }
   }
-  !PROPELLANT[LiquidFuel] {}
-  !PROPELLANT[Oxidizer] {}
-  !PROPELLANT[MonoPropellant] {}
-  PROPELLANT
+
+  MODULE
   {
-   name = Hydrazine
-   ratio = 100
+    name = ModuleEngineConfigs
+    type = ModuleRCS
+    techLevel = 1
+    origTechLevel = 1
+    engineType = L
+    origMass = 0.029
+    configuration = Hydrazine
+    modded = false
+    CONFIG
+    {
+      name = MMH+NTO
+      thrusterPower = 1
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 0.51135562
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.48864438
+      }
+      IspSL = 0.4
+      IspV = 0.952
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      thrusterPower = 0.578
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 1
+      }
+      IspSL = 0.23
+      IspV = 0.72
+    }
+    CONFIG
+    {
+      name = HTP
+      thrusterPower = 0.241
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 1
+      }
+      IspSL = 0.2
+      IspV = 0.465
+    }
+    CONFIG
+    {
+      name = Nitrogen
+      thrusterPower = 0.225
+      PROPELLANT
+      {
+        name = Nitrogen
+        ratio = 1
+      }
+      IspSL = 0.1
+      IspV = 0.195
+    }
+    CONFIG
+    {
+      name = NitrousOxide
+      thrusterPower = 0.225
+      PROPELLANT
+      {
+        name = NitrousOxide
+        ratio = 1
+      }
+      IspSL = 0.253
+      IspV = 0.5
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      thrusterPower = 0.993
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 0.47823219
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.52176781
+      }
+      IspSL = 0.396
+      IspV = 0.943
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      thrusterPower = 1
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 0.48657718
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.51342282
+      }
+      IspSL = 0.403
+      IspV = 0.955
+    }
   }
- }
-
- MODULE
- {
-  name = ModuleEngineConfigs
-  type = ModuleRCS
-  techLevel = 1
-  origTechLevel = 1
-  engineType = L
-  origMass = 0.029
-  configuration = Hydrazine
-  modded = false
-  CONFIG
-  {
-   name = MMH+NTO
-   thrusterPower = 1
-
-   PROPELLANT
-   {
-    name = MMH
-    ratio = 0.51135562
-   }
-   PROPELLANT
-   {
-    name = NTO
-    ratio = 0.48864438
-   }
-   IspSL = 0.4
-   IspV = 0.952
-
-
-   }
-  CONFIG
-  {
-   name = Hydrazine
-   thrusterPower = 0.578
-
-   PROPELLANT
-   {
-    name = Hydrazine
-    ratio = 1
-   }
-   IspSL = 0.23
-   IspV = 0.72
-
-
-   }
-  CONFIG
-  {
-   name = HTP
-   thrusterPower = 0.241
-
-   PROPELLANT
-   {
-    name = HTP
-    ratio = 1
-   }
-   IspSL = 0.2
-   IspV = 0.465
-
-
-   }
-  CONFIG
-  {
-   name = Nitrogen
-   thrusterPower = 0.225
-
-   PROPELLANT
-   {
-    name = Nitrogen
-    ratio = 1
-   }
-   IspSL = 0.1
-   IspV = 0.195
-
-
-   }
-  CONFIG
-  {
-   name = NitrousOxide
-   thrusterPower = 0.225
-
-   PROPELLANT
-   {
-    name = NitrousOxide
-    ratio = 1
-   }
-   IspSL = 0.253
-   IspV = 0.5
-
-
-   }
-  CONFIG
-  {
-   name = UDMH+NTO
-   thrusterPower = 0.993
-
-   PROPELLANT
-   {
-    name = UDMH
-    ratio = 0.47823219
-   }
-   PROPELLANT
-   {
-    name = NTO
-    ratio = 0.52176781
-   }
-   IspSL = 0.396
-   IspV = 0.943
-
-
-   }
-  CONFIG
-  {
-   name = Aerozine50+NTO
-   thrusterPower = 1
-
-   PROPELLANT
-   {
-    name = Aerozine50
-    ratio = 0.48657718
-   }
-   PROPELLANT
-   {
-    name = NTO
-    ratio = 0.51342282
-   }
-   IspSL = 0.403
-   IspV = 0.955
-
-
-   }
-
- }
 }
 
 @PART[vernierEngine]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]
 {
-    @MODULE[ModuleRCS]
+  @MODULE[ModuleRCS]
+  {
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    PROPELLANT
     {
-        !PROPELLANT[LiquidFuel] {}
-        !PROPELLANT[Oxidizer] {}
+        name = MMH
+        ratio = 0.437
+        %resourceFlowMode = STAGE_PRIORITY_FLOW
+    }
+    PROPELLANT
+    {
+        name = NTO
+        ratio = 0.563
+        %resourceFlowMode = STAGE_PRIORITY_FLOW
+    }
+    @atmosphereCurve
+    {
+        @key,0 = 0 304
+        @key,1 = 1 265
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleRCS
+    thrustRating = thrusterPower
+    techLevel = 2
+    origTechLevel = 2
+    engineType = O
+    origMass = 0.01
+    configuration = MMH+NTO
+    modded = false
+    CONFIG
+    {
+        name = MMH+NTO
+        thrusterPower = 0.8
         PROPELLANT
         {
             name = MMH
@@ -178,239 +189,184 @@
             ratio = 0.563
             %resourceFlowMode = STAGE_PRIORITY_FLOW
         }
-        @atmosphereCurve
-        {
-            @key,0 = 0 304
-            @key,1 = 1 265
-        }
+        IspSL = 0.953
+        IspV = 0.952
     }
-    MODULE
+    CONFIG
     {
-        name = ModuleEngineConfigs
-        type = ModuleRCS
-        thrustRating = thrusterPower
-        techLevel = 2
-        origTechLevel = 2
-        engineType = O
-        origMass = 0.01
-        configuration = MMH+NTO
-        modded = false
-        CONFIG
+        name = UDMH+NTO
+        thrusterPower = 0.75
+        PROPELLANT
         {
-            name = MMH+NTO
-            thrusterPower = 0.8
-            PROPELLANT
-            {
-                name = MMH
-                ratio = 0.437
-                %resourceFlowMode = STAGE_PRIORITY_FLOW
-            }
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.563
-                %resourceFlowMode = STAGE_PRIORITY_FLOW
-            }
-            IspSL = 0.953
-            IspV = 0.952
+            name = UDMH
+            ratio = 0.413
+            %resourceFlowMode = STAGE_PRIORITY_FLOW
         }
-        CONFIG
+        PROPELLANT
         {
-            name = UDMH+NTO
-            thrusterPower = 0.75
-            PROPELLANT
-            {
-                name = UDMH
-                ratio = 0.413
-                %resourceFlowMode = STAGE_PRIORITY_FLOW
-            }
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.587
-                %resourceFlowMode = STAGE_PRIORITY_FLOW
-            }
-            IspSL = 0.95
-            IspV = 0.943
+            name = NTO
+            ratio = 0.587
+            %resourceFlowMode = STAGE_PRIORITY_FLOW
         }
-        CONFIG
-        {
-            name = Aerozine+NTO
-            thrusterPower = 0.85
-            PROPELLANT
-            {
-                name = Aerozine50
-                ratio = 0.502
-                %resourceFlowMode = STAGE_PRIORITY_FLOW
-            }
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 0.498
-                %resourceFlowMode = STAGE_PRIORITY_FLOW
-            }
-            IspSL = 0.963
-            IspV = 0.955
-        }
+        IspSL = 0.95
+        IspV = 0.943
     }
+    CONFIG
+    {
+        name = Aerozine+NTO
+        thrusterPower = 0.85
+        PROPELLANT
+        {
+            name = Aerozine50
+            ratio = 0.502
+            %resourceFlowMode = STAGE_PRIORITY_FLOW
+        }
+        PROPELLANT
+        {
+            name = NTO
+            ratio = 0.498
+            %resourceFlowMode = STAGE_PRIORITY_FLOW
+        }
+        IspSL = 0.963
+        IspV = 0.955
+    }
+  }
 }
 
 
 @PART[linearRcs]:FOR[RealFuels_StockEngines] //
 {
- @mass = 0.011
+  @mass = 0.011
 
- @MODULE[ModuleRCS*]
- {
-  @thrusterPower = 0.578
-  !resourceName = DELETE
-  @atmosphereCurve
+  @MODULE[ModuleRCS*]
   {
-   @key,0 = 0 281
-   @key,1 = 1 101
+    @thrusterPower = 0.578
+    !resourceName = DELETE
+    @atmosphereCurve
+    {
+      @key,0 = 0 281
+      @key,1 = 1 101
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Hydrazine
+      ratio = 100
+    }
   }
-  !PROPELLANT[LiquidFuel] {}
-  !PROPELLANT[Oxidizer] {}
-  !PROPELLANT[MonoPropellant] {}
-  PROPELLANT
+
+  MODULE
   {
-   name = Hydrazine
-   ratio = 100
+    name = ModuleEngineConfigs
+    type = ModuleRCS
+    techLevel = 1
+    origTechLevel = 1
+    engineType = L
+    origMass = 0.029
+    configuration = Hydrazine
+    modded = false
+    CONFIG
+    {
+      name = MMH+NTO
+      thrusterPower = 1
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 0.51135562
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.48864438
+      }
+      IspSL = 0.4
+      IspV = 0.952
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      thrusterPower = 0.578
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 1
+      }
+      IspSL = 0.23
+      IspV = 0.72
+    }
+    CONFIG
+    {
+      name = HTP
+      thrusterPower = 0.241
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 1
+      }
+      IspSL = 0.2
+      IspV = 0.465
+    }
+    CONFIG
+    {
+      name = Nitrogen
+      thrusterPower = 0.225
+      PROPELLANT
+      {
+        name = Nitrogen
+        ratio = 1
+      }
+      IspSL = 0.1
+      IspV = 0.195
+    }
+    CONFIG
+    {
+      name = NitrousOxide
+      thrusterPower = 0.225
+      PROPELLANT
+      {
+        name = NitrousOxide
+        ratio = 1
+      }
+      IspSL = 0.253
+      IspV = 0.5
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      thrusterPower = 0.993
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 0.47823219
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.52176781
+      }
+      IspSL = 0.396
+      IspV = 0.943
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      thrusterPower = 1
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 0.48657718
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.51342282
+      }
+      IspSL = 0.403
+      IspV = 0.955
+    }
   }
- }
-
- MODULE
- {
-  name = ModuleEngineConfigs
-  type = ModuleRCS
-  techLevel = 1
-  origTechLevel = 1
-  engineType = L
-  origMass = 0.011
-  configuration = Hydrazine
-  modded = false
-  CONFIG
-  {
-   name = MMH+NTO
-   thrusterPower = 1
-
-   PROPELLANT
-   {
-    name = MMH
-    ratio = 0.51135562
-   }
-   PROPELLANT
-   {
-    name = NTO
-    ratio = 0.48864438
-   }
-   IspSL = 0.4
-   IspV = 0.952
-
-
-   }
-  CONFIG
-  {
-   name = Hydrazine
-   thrusterPower = 0.578
-
-   PROPELLANT
-   {
-    name = Hydrazine
-    ratio = 1
-   }
-   IspSL = 0.23
-   IspV = 0.72
-
-
-   }
-  CONFIG
-  {
-   name = HTP
-   thrusterPower = 0.241
-
-   PROPELLANT
-   {
-    name = HTP
-    ratio = 1
-   }
-   IspSL = 0.2
-   IspV = 0.465
-
-
-   }
-  CONFIG
-  {
-   name = Nitrogen
-   thrusterPower = 0.225
-
-   PROPELLANT
-   {
-    name = Nitrogen
-    ratio = 1
-   }
-   IspSL = 0.1
-   IspV = 0.195
-
-
-   }
-  CONFIG
-  {
-   name = NitrousOxide
-   thrusterPower = 0.225
-
-   PROPELLANT
-   {
-    name = NitrousOxide
-    ratio = 1
-   }
-   IspSL = 0.253
-   IspV = 0.5
-
-
-   }
-  CONFIG
-  {
-   name = UDMH+NTO
-   thrusterPower = 0.993
-
-   PROPELLANT
-   {
-    name = UDMH
-    ratio = 0.47823219
-   }
-   PROPELLANT
-   {
-    name = NTO
-    ratio = 0.52176781
-   }
-   IspSL = 0.396
-   IspV = 0.943
-
-
-   }
-  CONFIG
-  {
-   name = Aerozine50+NTO
-   thrusterPower = 1
-
-   PROPELLANT
-   {
-    name = Aerozine50
-    ratio = 0.48657718
-   }
-   PROPELLANT
-   {
-    name = NTO
-    ratio = 0.51342282
-   }
-   IspSL = 0.403
-   IspV = 0.955
-
-
-   }
-
- }
 }
 
 @PART[HotGasThruster-L]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]
@@ -676,59 +632,59 @@
 
 @PART[mk1-3pod]:FOR[zz_RealFuels_StockEngines]
 {
-    @MODULE[ModuleRCS*]
+  @MODULE[ModuleRCS*]
+  {
+    !resourceName = DELETE
+    @PROPELLANT
     {
-        !resourceName = DELETE
-        @PROPELLANT
+        name = Hydrazine
+        ratio = 100
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleRCSFX
+    thrustRating = thrusterPower
+    techLevel = 2
+    origTechLevel = 2
+    engineType = O
+    origMass = 2.60
+    configuration = Hydrazine
+    modded = false
+    CONFIG
+    {
+        name = Hydrazine
+        thrusterPower = 0.5
+
+        PROPELLANT
         {
             name = Hydrazine
-            ratio = 100
+            ratio = 1
         }
+        IspSL = 0.23
+        IspV = 0.72
     }
-
-    MODULE
+    CONFIG
     {
-        name = ModuleEngineConfigs
-        type = ModuleRCSFX
-        thrustRating = thrusterPower
-        techLevel = 2
-        origTechLevel = 2
-        engineType = O
-        origMass = 2.60
-        configuration = Hydrazine
-        modded = false
-        CONFIG
+        name = MMH+NTO
+        thrusterPower = 1
+        PROPELLANT
         {
-            name = Hydrazine
-            thrusterPower = 0.5
-
-            PROPELLANT
-            {
-                name = Hydrazine
-                ratio = 1
-            }
-            IspSL = 0.23
-            IspV = 0.72
+            name = MMH
+            ratio = 37.694087
+            DrawGauge = True
+            %resourceFlowMode = STACK_PRIORITY_SEARCH
         }
-        CONFIG
+        PROPELLANT
         {
-            name = MMH+NTO
-            thrusterPower = 1
-            PROPELLANT
-            {
-                name = MMH
-                ratio = 37.694087
-                DrawGauge = True
-                %resourceFlowMode = STACK_PRIORITY_SEARCH
-            }
-            PROPELLANT
-            {
-                name = NTO
-                ratio = 62.305913
-                %resourceFlowMode = STACK_PRIORITY_SEARCH
-            }
-            IspSL = 0.953
-            IspV = 0.952
+            name = NTO
+            ratio = 62.305913
+            %resourceFlowMode = STACK_PRIORITY_SEARCH
         }
+        IspSL = 0.953
+        IspV = 0.952
     }
+  }
 }

--- a/GameData/RealFuels-Stock/Squad/squad_rcs.cfg
+++ b/GameData/RealFuels-Stock/Squad/squad_rcs.cfg
@@ -5,7 +5,7 @@
 
 @PART[RCSBlock_v2]:FOR[RealFuels_StockEngines]
 {
-  @mass = 0.029
+  @mass = 0.032
 
   @MODULE[ModuleRCS*]
   {
@@ -33,7 +33,7 @@
     techLevel = 1
     origTechLevel = 1
     engineType = L
-    origMass = 0.029
+    origMass = 0.032
     configuration = Hydrazine
     modded = false
     CONFIG
@@ -146,20 +146,20 @@
     !PROPELLANT[Oxidizer] {}
     PROPELLANT
     {
-        name = MMH
-        ratio = 0.437
+        name = LqdHydrogen
+        ratio = 0.745
         %resourceFlowMode = STAGE_PRIORITY_FLOW
     }
     PROPELLANT
     {
-        name = NTO
-        ratio = 0.563
+        name = LqdOxygen
+        ratio = 0.255
         %resourceFlowMode = STAGE_PRIORITY_FLOW
     }
     @atmosphereCurve
     {
-        @key,0 = 0 304
-        @key,1 = 1 265
+        @key,0 = 0 347
+        @key,1 = 1 304
     }
   }
   MODULE
@@ -171,64 +171,64 @@
     origTechLevel = 2
     engineType = O
     origMass = 0.01
-    configuration = MMH+NTO
+    configuration = LqdHydrogen+LqdOxygen
     modded = false
     CONFIG
     {
-        name = MMH+NTO
-        thrusterPower = 0.8
-        PROPELLANT
-        {
-            name = MMH
-            ratio = 0.437
-            %resourceFlowMode = STAGE_PRIORITY_FLOW
-        }
-        PROPELLANT
-        {
-            name = NTO
-            ratio = 0.563
-            %resourceFlowMode = STAGE_PRIORITY_FLOW
-        }
-        IspSL = 0.953
-        IspV = 0.952
+      name = LqdHydrogen+LqdOxygen
+      thrusterPower = 0.75
+      PROPELLANT
+      {
+          name = LqdHydrogen
+          ratio = 0.745
+          %resourceFlowMode = STAGE_PRIORITY_FLOW
+      }
+      PROPELLANT
+      {
+          name = LqdOxygen
+          ratio = 0.255
+          %resourceFlowMode = STAGE_PRIORITY_FLOW
+      }
+      IspSL = 1.3000
+      IspV = 1.2700
     }
     CONFIG
     {
-        name = UDMH+NTO
-        thrusterPower = 0.75
-        PROPELLANT
-        {
-            name = UDMH
-            ratio = 0.413
-            %resourceFlowMode = STAGE_PRIORITY_FLOW
-        }
-        PROPELLANT
-        {
-            name = NTO
-            ratio = 0.587
-            %resourceFlowMode = STAGE_PRIORITY_FLOW
-        }
-        IspSL = 0.95
-        IspV = 0.943
+      name = LqdMethane+LqdOxygen
+      thrusterPower = 0.96
+      PROPELLANT
+      {
+          name = LqdMethane
+          ratio = 0.434
+          %resourceFlowMode = STAGE_PRIORITY_FLOW
+      }
+      PROPELLANT
+      {
+          name = LqdOxygen
+          ratio = 0.566
+          %resourceFlowMode = STAGE_PRIORITY_FLOW
+      }
+      IspSL = 1.0300
+      IspV = 1.0300
     }
     CONFIG
     {
-        name = Aerozine+NTO
-        thrusterPower = 0.85
-        PROPELLANT
-        {
-            name = Aerozine50
-            ratio = 0.502
-            %resourceFlowMode = STAGE_PRIORITY_FLOW
-        }
-        PROPELLANT
-        {
-            name = NTO
-            ratio = 0.498
-            %resourceFlowMode = STAGE_PRIORITY_FLOW
-        }
-        IspSL = 0.963
-        IspV = 0.955
+      name = Kerosene+LqdOxygen
+      thrusterPower = 1.0
+      PROPELLANT
+      {
+          name = Kerosene
+          ratio = 0.367
+          %resourceFlowMode = STAGE_PRIORITY_FLOW
+      }
+      PROPELLANT
+      {
+          name = LqdOxygen
+          ratio = 0.633
+          %resourceFlowMode = STAGE_PRIORITY_FLOW
+      }
+      IspSL = 1.000
+      IspV = 1.000
     }
   }
 }
@@ -236,7 +236,7 @@
 
 @PART[linearRcs]:FOR[RealFuels_StockEngines] //
 {
-  @mass = 0.011
+  @mass = 0.016
 
   @MODULE[ModuleRCS*]
   {
@@ -264,7 +264,7 @@
     techLevel = 1
     origTechLevel = 1
     engineType = L
-    origMass = 0.029
+    origMass = 0.016
     configuration = Hydrazine
     modded = false
     CONFIG


### PR DESCRIPTION
Hey there,

I used to play with RealFuels/Stock Configs a lot, so thank you so much for keeping it alive. :)
There seem to be some inconsistencies in the configs for some of the ReStock+ engines, which is the main focus of this pull request, but I also added fuel switching for the RCS thrusters in ReStock+ and changed the stock Vernor Engine. The commit messages include the rationale for some of the changes if you're interested.
I also have some ideas about additional fuel types for certain engines, or making certain engines pressure-fed, but I don't know whether those are relevant so I haven't implemented them in this PR.