### PR TITLE
Make LV-1(R) and O-10 pressure fed

### DIFF
--- a/GameData/RealFuels-Stock/Squad/microEngine_LV-1-Ant.cfg
+++ b/GameData/RealFuels-Stock/Squad/microEngine_LV-1-Ant.cfg
@@ -166,9 +166,9 @@
       IspSL = 0.9600
       IspV = 0.9500
       throttle = 0
-      ignitions = 24
+      ignitions = 0
       ullage = true
-      pressureFed = false
+      pressureFed = true
       IGNITOR_RESOURCE
       {
         name = ElectricCharge
@@ -178,9 +178,9 @@
 
     }
   }
-  ignitions = 24
+  ignitions = 0
   ullage = true
-  pressureFed = false
+  pressureFed = true
   IGNITOR_RESOURCE
   {
     name = ElectricCharge

--- a/GameData/RealFuels-Stock/Squad/omsEngine_Puff.cfg
+++ b/GameData/RealFuels-Stock/Squad/omsEngine_Puff.cfg
@@ -60,9 +60,9 @@
       IspSL = 0.2740
       IspV = 0.7200
       throttle = 0
-      ignitions = 24
+      ignitions = 0
       ullage = true
-      pressureFed = false
+      pressureFed = true
       IGNITOR_RESOURCE
       {
         name = ElectricCharge
@@ -86,9 +86,9 @@
       IspSL = 0.1770
       IspV = 0.4650
       throttle = 0
-      ignitions = 24
+      ignitions = 0
       ullage = true
-      pressureFed = false
+      pressureFed = true
       IGNITOR_RESOURCE
       {
         name = ElectricCharge
@@ -118,9 +118,9 @@
       IspSL = 0.9600
       IspV = 0.9500
       throttle = 0
-      ignitions = 24
+      ignitions = 0
       ullage = true
-      pressureFed = false
+      pressureFed = true
       IGNITOR_RESOURCE
       {
         name = ElectricCharge
@@ -130,9 +130,9 @@
 
     }
   }
-  ignitions = 24
+  ignitions = 0
   ullage = true
-  pressureFed = false
+  pressureFed = true
   IGNITOR_RESOURCE
   {
     name = ElectricCharge

--- a/GameData/RealFuels-Stock/Squad/radialEngineMini_LV-1R_Spider.cfg
+++ b/GameData/RealFuels-Stock/Squad/radialEngineMini_LV-1R_Spider.cfg
@@ -168,9 +168,9 @@
       IspSL = 0.9600
       IspV = 0.9500
       throttle = 0
-      ignitions = 24
+      ignitions = 0
       ullage = true
-      pressureFed = false
+      pressureFed = true
       IGNITOR_RESOURCE
       {
         name = ElectricCharge
@@ -180,9 +180,9 @@
 
     }
   }
-  ignitions = 24
+  ignitions = 0
   ullage = true
-  pressureFed = false
+  pressureFed = true
   IGNITOR_RESOURCE
   {
     name = ElectricCharge


### PR DESCRIPTION
I'm not sure about the logic behind making pressure-fed engines have limited ignitions or require ullage (as some of the other configured engines do), so these require ullage but have unlimited ignitions. These can be switched around as necessary.