### PR TITLE
Fix NFSpacecraft engines

### DIFF
--- a/GameData/RealFuels-Stock/NearFutureSpacecraft/engine-rocket-pack-1.cfg
+++ b/GameData/RealFuels-Stock/NearFutureSpacecraft/engine-rocket-pack-1.cfg
@@ -27,14 +27,14 @@
     PROPELLANT
     {
       name = MMH
-      ratio = 41.738630
+      ratio = 41.73862982153138
       DrawGauge = True
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
       name = NTO
-      ratio = 58.261370
+      ratio = 58.26137017846862
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
   }

--- a/GameData/RealFuels-Stock/NearFutureSpacecraft/engine-rocket-pack-2.cfg
+++ b/GameData/RealFuels-Stock/NearFutureSpacecraft/engine-rocket-pack-2.cfg
@@ -26,16 +26,16 @@
     !PROPELLANT[MonoPropellant] {}
     PROPELLANT
     {
-    name = MMH
-    ratio = 41.73862982153138
-    DrawGauge = True
-    %resourceFlowMode = STACK_PRIORITY_SEARCH
+      name = MMH
+      ratio = 41.73862982153138
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
-    name = NTO
-    ratio = 58.26137017846862
-    %resourceFlowMode = STACK_PRIORITY_SEARCH
+      name = NTO
+      ratio = 58.26137017846862
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
   }
   

--- a/GameData/RealFuels-Stock/NearFutureSpacecraft/orbital-engine-0625.cfg
+++ b/GameData/RealFuels-Stock/NearFutureSpacecraft/orbital-engine-0625.cfg
@@ -5,7 +5,7 @@
 @PART[orbital-engine-0625]:FOR[RealFuels_StockEngines]
 {
 
-  @mass = 0.08
+  @mass = 0.06
   @cost = 142
   %entryCost = 710
   @maxTemp = 1450
@@ -26,16 +26,16 @@
     !PROPELLANT[MonoPropellant] {}
     PROPELLANT
     {
-    name = MMH
-    ratio = 39.726027397260275
-    DrawGauge = True
-    %resourceFlowMode = STACK_PRIORITY_SEARCH
+      name = MMH
+      ratio = 39.726027397260275
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
-    name = NTO
-    ratio = 60.273972602739725
-    %resourceFlowMode = STACK_PRIORITY_SEARCH
+      name = NTO
+      ratio = 60.273972602739725
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
     }  
   }
   
@@ -46,14 +46,14 @@
     techLevel = 3
     origTechLevel = 3
     engineType = O
-    origMass = 0.08
+    origMass = 0.06
     configuration = MMH+NTO
     modded = false
 
     CONFIG
     {
       name = MMH+NTO
-      maxThrust = 140
+      maxThrust = 14
       heatProduction = 114
       PROPELLANT
       {

--- a/GameData/RealFuels-Stock/NearFutureSpacecraft/orbital-engine-125.cfg
+++ b/GameData/RealFuels-Stock/NearFutureSpacecraft/orbital-engine-125.cfg
@@ -27,16 +27,16 @@
     PROPELLANT
     {
       name = MMH
-      ratio = 39.726027
+      ratio = 39.726027397260275
       DrawGauge = True
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
       name = NTO
-      ratio = 60.273973
+      ratio = 60.273972602739725
       %resourceFlowMode = STACK_PRIORITY_SEARCH
-    }
+    }  
   }
   
   MODULE
@@ -90,14 +90,14 @@
       PROPELLANT
       {
         name = Aerozine50
-        ratio = 39.18918918918919
+        ratio = 50.173
         DrawGauge = True
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = NTO
-        ratio = 60.81081081081081
+        ratio = 49.827
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 0.9600

--- a/GameData/RealFuels-Stock/NearFutureSpacecraft/orbital-engine-25.cfg
+++ b/GameData/RealFuels-Stock/NearFutureSpacecraft/orbital-engine-25.cfg
@@ -5,7 +5,7 @@
 @PART[orbital-engine-25]:FOR[RealFuels_StockEngines]
 {
 
-  @mass = 0.65
+  @mass = 0.35
   @cost = 323
   %entryCost = 1615
   @maxTemp = 1523
@@ -27,16 +27,16 @@
     PROPELLANT
     {
       name = MMH
-      ratio = 40.707468
+      ratio = 39.726027397260275
       DrawGauge = True
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
       name = NTO
-      ratio = 59.292532
+      ratio = 60.273972602739725
       %resourceFlowMode = STACK_PRIORITY_SEARCH
-    }
+    }  
   }
   
   MODULE
@@ -46,7 +46,7 @@
     techLevel = 4
     origTechLevel = 4
     engineType = O
-    origMass = 0.65
+    origMass = 0.35
     configuration = MMH+NTO
     modded = false
 
@@ -58,14 +58,14 @@
       PROPELLANT
       {
         name = MMH
-        ratio = 40.707467714766985
+        ratio = 39.726027397260275
         DrawGauge = True
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = NTO
-        ratio = 59.292532285233015
+        ratio = 60.273972602739725
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 0.9600
@@ -112,12 +112,12 @@ B9_TANK_TYPE
   RESOURCE
   {
     name = MMH
-    unitsPerVolume = 0.40707
+    unitsPerVolume = 0.39726
   }
   RESOURCE
   {
     name = NTO
-    unitsPerVolume = 0.59293
+    unitsPerVolume = 0.60274
   }
 }
 

--- a/GameData/RealFuels-Stock/NearFutureSpacecraft/orbital-engine-375.cfg
+++ b/GameData/RealFuels-Stock/NearFutureSpacecraft/orbital-engine-375.cfg
@@ -5,7 +5,7 @@
 @PART[orbital-engine-375]:FOR[RealFuels_StockEngines] 
 {
 
-  @mass = 2.5
+  @mass = 1.75
   @cost = 957
   %entryCost = 9785
   @maxTemp = 1666
@@ -27,16 +27,16 @@
     PROPELLANT
     {
       name = MMH
-      ratio = 39.726027
+      ratio = 39.726027397260275
       DrawGauge = True
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
       name = NTO
-      ratio = 60.273973
+      ratio = 60.273972602739725
       %resourceFlowMode = STACK_PRIORITY_SEARCH
-    }
+    }  
   }
   
   MODULE
@@ -46,7 +46,7 @@
     techLevel = 3
     origTechLevel = 3
     engineType = O
-    origMass = 2.5
+    origMass = 1.75
     configuration = MMH+NTO
     modded = false
 
@@ -90,14 +90,14 @@
       PROPELLANT
       {
         name = Aerozine50
-        ratio = 39.18918918918919
+        ratio = 50.173
         DrawGauge = True
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = NTO
-        ratio = 60.81081081081081
+        ratio = 49.827
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 0.9600
@@ -151,6 +151,77 @@
   }
 
   
+}
+
+@PART[orbital-engine-375]:FOR[z_RealFuels_StockEngines]
+{   
+  @MODULE[ModuleB9PartSwitch],1
+  {
+    !SUBTYPE,1 {}
+    SUBTYPE
+    {
+      name = MMH+NTO
+      transform = Tanks
+      tankType = OE-375_MMH+NTO
+    }
+    SUBTYPE
+    {
+      name = Aerozine50+NTO
+      transform = Tanks
+      tankType = OE-375_Az50+NTO
+    }
+    SUBTYPE
+    {
+      name = Hydrazine
+      transform = Tanks
+      tankType = OE-375_Hydrazine
+    }
+  }
+}
+
+B9_TANK_TYPE
+{
+  name = OE-375_MMH+NTO
+  tankMass = 0.0016
+  tankCost = 0.75
+  RESOURCE
+  {
+    name = MMH
+    unitsPerVolume = 0.39726
+  }
+  RESOURCE
+  {
+    name = NTO
+    unitsPerVolume = 0.60247
+  }
+}
+
+B9_TANK_TYPE
+{
+  name = OE-375_Az50+NTO
+  tankMass = 0.0016
+  tankCost = 0.75
+  RESOURCE
+  {
+    name = Aerozine50
+    unitsPerVolume = 0.50173
+  }
+  RESOURCE
+  {
+    name = NTO
+    unitsPerVolume = 0.49827
+  }
+}
+
+B9_TANK_TYPE
+{
+  name = OE-375_Hydrazine
+  tankMass = 0.0016
+  tankCost = 0.75
+  RESOURCE
+  {
+    name = Hydrazine
+    unitsPerVolume = 1
 }
 
 // ---------- //  


### PR DESCRIPTION
Taken from the commit message:

* Fix thrust on the 0.625m orbital engine
* Tweak orbital engine masses
  * 0.625m: 0.08t → 0.06t
  * 1.25m: unchanged (0.5t)
  * 2.5m: 0.65t → 0.35t
  * 3.75m: 2.5t → 1.75t

Rationale: These modifications make the 0.625m and 2.5m engines slightly weaker in terms of TWR than the LV-909 and the Poodle respectively.
The 3.75m engine received a mass reduction such that its mass is less than four 1.25m engines. The 2.5m engine's mass is greater than 6x0.625m engines because it has far more thrust than six 0.625m engines.
* Make fuel mixtures consistent within orbital and landing engines
* Patch B9PS on 3.75m orbital engine to include configurable tankage

NB: The 3.75m OE will still need a dedicated ServiceModule tank for the feed pressure, and the fuel mixture will need to be switched manually between MMH/Aerozine/Hydrazine.
AFAIK there is no way for B9PS to switch to a MFT tank, but once a pressurized tank is present it should be able to draw from the "integrated" tanks just fine.