### PR TITLE
Generic RCS patch tweaks

### DIFF
--- a/GameData/RealFuels-Stock/000_GlobalPatches/Non_Configured_Parts.cfg
+++ b/GameData/RealFuels-Stock/000_GlobalPatches/Non_Configured_Parts.cfg
@@ -1,7 +1,5 @@
-// All Engines that are not configured by RealFuels-Stock are getting replaced K/LOx as their base fuel.
-// All RCS Thrusters not configured getting standard rcs configs applied.
+// All engines that are not configured by RealFuels-Stock will use Kerolox
 
-// LiquidFuel to Kerosene
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]]:FOR[z_RealFuels_StockEngines]
 {
 	@MODULE[ModuleEngines*],*
@@ -13,8 +11,6 @@
 		}
 	}
 }
-
-// Oxidizer to LqdOxygen
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Oxidizer]]]:FOR[z_RealFuels_StockEngines]
 {
 	@MODULE[ModuleEngines*],*
@@ -27,13 +23,14 @@
 	}
 }
 
-// Auto generated RCS configuration if engine isnt configure before hand. 
-@PART[*]:HAS[@MODULE[ModuleRCSFX]:HAS[#resourceName[MonoPropellant]]]:FOR[z_RealFuels_StockEngines]    
+// Configures all RCS thrusters without explicit configuration to have hypergolic configs
+// LFO RCS should be configured separately
+@PART[*]:HAS[@MODULE[ModuleRCSFX]&!MODULE[ModuleEngineConfigs]]:FOR[z_RealFuels_StockEngines]
 {
-	@mass *= 0.75
+  @mass *= 0.8
+
   @MODULE[ModuleRCSFX]
   {
-    @thrusterPower *= 0.5
     !resourceName = DELETE
     @atmosphereCurve
     {
@@ -45,8 +42,13 @@
     !PROPELLANT[MonoPropellant] {}
     PROPELLANT
     {
-      name = Hydrazine
-      ratio = 100
+      name = Aerozine50
+      ratio = 0.48657718
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 0.51342282
     }
   }
 
@@ -57,69 +59,13 @@
     techLevel = 1
     origTechLevel = 1
     engineType = L
-    origMass = #$../mass$
-    configuration = Hydrazine
+    origMass = #$/mass$
+    configuration = Aerozine50+NTO
     modded = false
-		CONFIG 
-		{
-			name = Hydrazine
-			thrusterPower = #$../../MODULE[ModuleRCSFX]/thrusterPower$
-			PROPELLANT
-    	{
-				name = Hydrazine
-				ratio = 100
-    	}
-      IspSL = 0.23
-      IspV = 0.72
-		}
-
-		CONFIG 
-		{
-			name = HTP 
-			thrusterPower = #$../../MODULE[ModuleRCSFX]/thrusterPower$
-			@thrusterPower *= 0.5
-			PROPELLANT
-      {
-        name = HTP
-        ratio = 1
-      }
-      IspSL = 0.2
-      IspV = 0.465
-		}	
-
-		CONFIG
-    {
-      name = Nitrogen
-			thrusterPower = #$../../MODULE[ModuleRCSFX]/thrusterPower$
-			@thrusterPower *= 0.5
-      PROPELLANT
-      {
-        name = Nitrogen
-        ratio = 1
-      }
-      IspSL = 0.1
-      IspV = 0.195
-    }
-
-		CONFIG
-    {
-      name = NitrousOxide
-			thrusterPower = #$../../MODULE[ModuleRCSFX]/thrusterPower$
-			@thrusterPower *= 0.5
-      PROPELLANT
-      {
-        name = NitrousOxide
-        ratio = 1
-      }
-      IspSL = 0.253
-      IspV = 0.5
-    }
-
-		CONFIG
+    CONFIG
     {
       name = MMH+NTO
-			thrusterPower = #$../../MODULE[ModuleRCSFX]/thrusterPower$
-			@thrusterPower *= 2
+      thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
       PROPELLANT
       {
         name = MMH
@@ -133,31 +79,63 @@
       IspSL = 0.4
       IspV = 0.952
     }
-
-		CONFIG
+    CONFIG
     {
-      name = Aerozine50+NTO
-			thrusterPower = #$../../MODULE[ModuleRCSFX]/thrusterPower$
-			@thrusterPower *= 2
+      name = Hydrazine
+      thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+      @thrusterPower *= 0.578
       PROPELLANT
       {
-        name = Aerozine50
-        ratio = 0.48657718
+        name = Hydrazine
+        ratio = 1
       }
-      PROPELLANT
-      {
-        name = NTO
-        ratio = 0.51342282
-      }
-      IspSL = 0.403
-      IspV = 0.955
+      IspSL = 0.23
+      IspV = 0.72
     }
-
-		CONFIG
+    CONFIG
+    {
+      name = HTP
+      thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+      @thrusterPower *= 0.241
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 1
+      }
+      IspSL = 0.2
+      IspV = 0.465
+    }
+    CONFIG
+    {
+      name = Nitrogen
+      thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+      @thrusterPower *= 0.225
+      PROPELLANT
+      {
+        name = Nitrogen
+        ratio = 1
+      }
+      IspSL = 0.1
+      IspV = 0.195
+    }
+    CONFIG
+    {
+      name = NitrousOxide
+      thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+      @thrusterPower *= 0.225
+      PROPELLANT
+      {
+        name = NitrousOxide
+        ratio = 1
+      }
+      IspSL = 0.253
+      IspV = 0.5
+    }
+    CONFIG
     {
       name = UDMH+NTO
-			thrusterPower = #$../../MODULE[ModuleRCSFX]/thrusterPower$
-			@thrusterPower *= 1.95
+      thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+      @thrusterPower *= 0.993
       PROPELLANT
       {
         name = UDMH
@@ -171,6 +149,22 @@
       IspSL = 0.396
       IspV = 0.943
     }
-	}
-
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 0.48657718
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 0.51342282
+      }
+      IspSL = 0.403
+      IspV = 0.955
+    }
+  }
 }


### PR DESCRIPTION
* Change default fuel to Aerozine50/NTO

Rationale: Az50+NTO is used by most orbital maneuvering engines in stock and has a thrust multiplier of 1, which simplifies the thrust calculations for other fuels.
* Key the HAS block off of the absence of a ModuleEngineConfigs

Rationale: This will allow it to catch all unconfigured RCS thrusters.
NB: This ends up patching _all_ RCS thrusters to use hypergolics, which may not be ideal for RCS thrusters that in stock will burn LFO. Separate patches will be necessary for those thrusters. (note: I plan on writing patches for NF Launch Vehicles, which has a couple of LFO RCS thrusters.)
* Change the mass multiplier to 0.8x to be consistent with Squad RCS