### PR TITLE
Preliminary KerbalAtomics compatibility

### DIFF
--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-1.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-1.cfg
@@ -1,0 +1,218 @@
+@PART[ntr-gc-25-1]:FOR[RealFuels_StockEngines]
+{
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 820
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 100.000000
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 6
+    origTechLevel = 6
+    engineType = N
+    origMass = 11
+    configuration = NTRLqdHydrogen
+    modded = false
+
+    CONFIG
+    {
+      name = NTRLqdHydrogen
+      maxThrust = 820
+      heatProduction = 1310.377304
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 8.2
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = NTRLqdMethane
+      maxThrust = 1379
+      heatProduction = 1310.377304
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.6689
+      IspV = 0.6689
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 8.2
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = NTRLqdAmmonia
+      maxThrust = 1252
+      heatProduction = 1310.377304
+      PROPELLANT
+      {
+        name = LqdAmmonia
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.5331
+      IspV = 0.5331
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 8.2
+      } 
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+        name = ElectricCharge
+        amount = 8.2
+    }
+  }
+  !MODULE[ModuleAlternator] {}
+  !MODULE[ModuleGenerator] {}
+  !RESOURCE[EnrichedUranium] {}
+  !RESOURCE[DepletedUranium] {}
+  MODULE
+  {
+    name = ModuleAlternator
+    OUTPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = -68.33333333333333E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 68.33333333333333E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 41
+    }
+  }
+  MODULE
+  {
+    name = ModuleGenerator
+    isAlwaysActive = true
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 20.5
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 68.33333333333333E-18
+    }
+    INPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = 68.33333333333333E-18
+    }
+  }
+  RESOURCE
+  {
+    name = EnrichedUranium
+    amount = 68.33333333333333
+    maxAmount = 68.33333333333333
+  }
+  RESOURCE
+  {
+    name = DepletedUranium
+    amount = 0
+    maxAmount = 68.33333333333333
+  }
+}
+
+@PART[ntr-gc-25-1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+  PLUME
+  {
+    name = Nuclear_GasCore_LH2
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.45
+
+    plumePosition = 0,0,0
+    plumeScale = 0.45
+  }
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@type = ModuleEnginesRF
+		@CONFIG,*
+		{
+			%powerEffectName = Nuclear_GasCore_LH2
+		}
+	}
+}

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-1.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-1.cfg
@@ -20,8 +20,8 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesRF
-    techLevel = 6
-    origTechLevel = 6
+    techLevel = 3
+    origTechLevel = 3
     engineType = N
     origMass = 11
     configuration = NTRLqdHydrogen
@@ -44,8 +44,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 1.0000
-      IspV = 1.0000
+      IspSL = 1.4737
+      IspV = 1.9118
       throttle = 0
       ignitions = 0
       ullage = true
@@ -75,8 +75,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 0.6689
-      IspV = 0.6689
+      IspSL = 0.9858
+      IspV = 1.2788
       throttle = 0
       ignitions = 0
       ullage = true
@@ -106,8 +106,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 0.5331
-      IspV = 0.5331
+      IspSL = 0.7856
+      IspV = 1.019
       throttle = 0
       ignitions = 0
       ullage = true

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-2.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-2.cfg
@@ -20,8 +20,8 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesRF
-    techLevel = 6
-    origTechLevel = 6
+    techLevel = 3
+    origTechLevel = 3
     engineType = N
     origMass = 16
     configuration = NTRLqdHydrogen
@@ -44,8 +44,8 @@
         name = EnrichedUranium
         ratio = 0.0001
       }
-      IspSL = 1.0000
-      IspV = 1.0000
+      IspSL = 3.0263
+      IspV = 3.3529
       throttle = 0
       ignitions = 0
       ullage = true
@@ -75,8 +75,8 @@
         name = EnrichedUranium
         ratio = 0.0001
       }
-      IspSL = 0.6689
-      IspV = 0.6689
+      IspSL = 2.0243
+      IspV = 2.2428
       throttle = 0
       ignitions = 0
       ullage = true
@@ -106,8 +106,8 @@
         name = EnrichedUranium
         ratio = 0.0001
       }
-      IspSL = 0.5331
-      IspV = 0.5331
+      IspSL = 1.6133
+      IspV = 1.7874
       throttle = 0
       ignitions = 0
       ullage = true

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-2.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-2.cfg
@@ -1,0 +1,221 @@
+@PART[ntr-gc-25-2]:FOR[RealFuels_StockEngines]
+{
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 1540
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 100.000000
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 6
+    origTechLevel = 6
+    engineType = N
+    origMass = 16
+    configuration = NTRLqdHydrogen
+    modded = false
+
+    CONFIG
+    {
+      name = NTRLqdHydrogen
+      maxThrust = 1540
+      heatProduction = 981.6286842
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.0001
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 15.4
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = NTRLqdMethane
+      maxThrust = 2590
+      heatProduction = 981.6286842
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.0001
+      }
+      IspSL = 0.6689
+      IspV = 0.6689
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 15.4
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = NTRLqdAmmonia
+      maxThrust = 2352
+      heatProduction = 981.6286842
+      PROPELLANT
+      {
+        name = LqdAmmonia
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.0001
+      }
+      IspSL = 0.5331
+      IspV = 0.5331
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 15.4
+      }
+      
+      
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 15.4
+    }
+  }
+
+  !MODULE[ModuleAlternator] {}
+  !MODULE[ModuleGenerator] {}
+  !RESOURCE[EnrichedUranium] {}
+  !RESOURCE[DepletedUranium] {}
+  MODULE
+  {
+    name = ModuleAlternator
+    OUTPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = -128.33333333333334E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 128.33333333333334E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 77
+    }
+  }
+  MODULE
+  {
+    name = ModuleGenerator
+    isAlwaysActive = true
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 38.5
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 128.33333333333334E-18
+    }
+    INPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = 128.33333333333334E-18
+    }
+  }
+  RESOURCE
+  {
+    name = EnrichedUranium
+    amount = 128.33333333333334
+    maxAmount = 128.33333333333334
+  }
+  RESOURCE
+  {
+    name = DepletedUranium
+    amount = 0
+    maxAmount = 128.33333333333334
+  }
+}
+
+@PART[ntr-gc-25-2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+  PLUME
+  {
+    name = Nuclear_GasCore_Open_LH2
+    transformName = fxTransformPlume
+    localRotation = 0,0,0
+    localPosition = 0,0,-2.8
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 1
+
+    plumePosition = 0,0,0
+    plumeScale = 1
+  }
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@type = ModuleEnginesRF
+		@CONFIG,*
+		{
+			%powerEffectName = Nuclear_GasCore_Open_LH2
+		}
+	}
+}

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-3.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-3.cfg
@@ -19,8 +19,8 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesRF
-    techLevel = 6
-    origTechLevel = 6
+    techLevel = 3
+    origTechLevel = 3
     engineType = N
     origMass = 12
     configuration = NTRLqdHydrogen
@@ -43,8 +43,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 1.0000
-      IspV = 1.0000
+      IspSL = 3.0789
+      IspV = 1.4706
       throttle = 0
       ignitions = 0
       ullage = true
@@ -72,8 +72,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 0.6689
-      IspV = 0.6689
+      IspSL = 2.0595
+      IspV = 0.9837
       throttle = 0
       ignitions = 0
       ullage = true
@@ -101,8 +101,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 0.5331
-      IspV = 0.5331
+      IspSL = 1.6414
+      IspV = 0.7840
       throttle = 0
       ignitions = 0
       ullage = true

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-3.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-gc-25-3.cfg
@@ -1,0 +1,214 @@
+@PART[ntr-gc-25-3]:FOR[RealFuels_StockEngines] //Blank Engine
+{
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 1950
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 100.000000
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 6
+    origTechLevel = 6
+    engineType = N
+    origMass = 12
+    configuration = NTRLqdHydrogen
+    modded = false
+
+    CONFIG
+    {
+      name = NTRLqdHydrogen
+      maxThrust = 1950
+      heatProduction = 3296.59461
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 19.5
+      }
+    }
+    CONFIG
+    {
+      name = NTRLqdMethane
+      maxThrust = 3280
+      heatProduction = 3296.59461
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.6689
+      IspV = 0.6689
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 19.5
+      }
+    }
+    CONFIG
+    {
+      name = NTRLqdAmmonia
+      maxThrust = 2978
+      heatProduction = 3296.59461
+      PROPELLANT
+      {
+        name = LqdAmmonia
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.5331
+      IspV = 0.5331
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 19.5
+      }
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 19.5
+    }
+  }
+
+  !MODULE[ModuleAlternator] {}
+  !MODULE[ModuleGenerator] {}
+  !RESOURCE[EnrichedUranium] {}
+  !RESOURCE[DepletedUranium] {}
+  MODULE
+  {
+    name = ModuleAlternator
+    OUTPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = -162.5E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 162.5E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 97.5
+    }
+  }
+  MODULE
+  {
+    name = ModuleGenerator
+    isAlwaysActive = true
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 48.75
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 162.5E-18
+    }
+    INPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = 162.5E-18
+    }
+  }
+  RESOURCE
+  {
+    name = EnrichedUranium
+    amount = 162.5
+    maxAmount = 162.5
+  }
+  RESOURCE
+  {
+    name = DepletedUranium
+    amount = 0
+    maxAmount = 162.5
+  }
+}
+
+@PART[ntr-gc-25-3]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+  PLUME
+  {
+    name = Nuclear_GasCore_LH2
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.45
+
+    plumePosition = 0,0,0
+    plumeScale = 0.45
+  }
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@type = ModuleEnginesRF
+		@CONFIG,*
+		{
+			%powerEffectName = Nuclear_GasCore_LH2
+		}
+	}
+}

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-0625-1.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-0625-1.cfg
@@ -1,0 +1,202 @@
+@PART[ntr-sc-0625-1]:FOR[RealFuels_StockEngines]
+{
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 12
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 100.000000
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 3
+    origTechLevel = 3
+    engineType = N
+    origMass = 0.35
+    configuration = NTRLqdHydrogen
+    modded = false
+    CONFIG
+    {
+      name = NTRLqdHydrogen
+      maxThrust = 12
+      heatProduction = 346.7740914
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.5000
+      IspV = 1.1000
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.12
+      }
+    }
+    CONFIG
+    {
+      name = NTRLqdAmmonia
+      maxThrust = 18
+      heatProduction = 346.7740914
+      PROPELLANT
+      {
+        name = LqdAmmonia
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.2666
+      IspV = 0.5864
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.12
+      }
+    }
+    CONFIG
+    {
+      name = NTRLqdMethane
+      maxThrust = 20
+      heatProduction = 346.7740914
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.3345
+      IspV = 0.7358
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.12
+      }
+    }
+  }
+  ignitions = -1
+  ullage = true
+  pressureFed = false
+  IGNITOR_RESOURCE
+  {
+    name = ElectricCharge
+    amount = 0.12
+  }
+  !MODULE[ModuleAlternator] {}
+  !MODULE[ModuleGenerator] {}
+  !RESOURCE[EnrichedUranium] {}
+  !RESOURCE[DepletedUranium] {}
+  MODULE
+  {
+    name = ModuleAlternator
+    OUTPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = -1E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 1E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 0.5
+    }
+  }
+  MODULE
+  {
+    name = ModuleGenerator
+    isAlwaysActive = true
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = -0.5
+    }
+  }
+  RESOURCE
+  {
+    name = EnrichedUranium
+    amount = 1
+    maxAmount = 1
+  }
+  RESOURCE
+  {
+    name = DepletedUranium
+    amount = 0
+    maxAmount = 1
+  }
+}
+
+@PART[ntr-sc-0625-1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+  PLUME
+  {
+    name = Nuclear_SolidCore_LH2
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.45
+
+    plumePosition = 0,0,0
+    plumeScale = 0.45
+  }
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@type = ModuleEnginesRF
+		@CONFIG,*
+		{
+			%powerEffectName = Nuclear_SolidCore_LH2
+		}
+	}
+}

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-0625-1.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-0625-1.cfg
@@ -42,8 +42,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 0.5000
-      IspV = 1.1000
+      IspSL = 0.4737
+      IspV = 1.1176
       throttle = 0
       ignitions = 0
       ullage = true
@@ -71,8 +71,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 0.2666
-      IspV = 0.5864
+      IspSL = 0.2525
+      IspV = 0.5958
       throttle = 0
       ignitions = 0
       ullage = true
@@ -100,8 +100,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 0.3345
-      IspV = 0.7358
+      IspSL = 0.3169
+      IspV = 0.7476
       throttle = 0
       ignitions = 0
       ullage = true

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-125-1.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-125-1.cfg
@@ -1,0 +1,216 @@
+@PART[ntr-sc-125-1]:FOR[RealFuels_StockEngines]
+{
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 67
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 100.000000
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = EnrichedUranium
+      ratio = 0.00000000001
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.67
+    }
+  }
+
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[LOxAugmented]]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 160
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 93.75
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 6.25
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = EnrichedUranium
+      ratio = 0.00000000001
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 1.6
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 4
+    origTechLevel = 4
+    engineType = N
+    origMass = 2.3
+    configuration = NTRLqdHydrogen
+    modded = false
+    CONFIG
+    {
+      name = NTRLqdHydrogen
+      maxThrust = 67
+      heatProduction = 299.3590569
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.5000
+      IspV = 1.0800
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.67
+      }
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.67
+    }
+  }
+  
+  !MODULE[ModuleAlternator] {}
+  !MODULE[ModuleGenerator] {}
+  !RESOURCE[EnrichedUranium] {}
+  !RESOURCE[DepletedUranium] {}
+  MODULE
+  {
+    name = ModuleAlternator
+    OUTPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = -5.583333333333333E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 5.583333333333333E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 3.35
+    }
+  }
+  MODULE
+  {
+    name = ModuleGenerator
+    isAlwaysActive = true
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 1.675
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 5.583333333333333E-18
+    }
+    INPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = 5.583333333333333E-18
+    }
+  }
+  RESOURCE
+  {
+    name = EnrichedUranium
+    amount = 5.583333333333333
+    maxAmount = 5.583333333333333
+  }
+  RESOURCE
+  {
+    name = DepletedUranium
+    amount = 0
+    maxAmount = 5.583333333333333
+  }
+}
+
+@PART[ntr-sc-125-1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+  PLUME
+  {
+    name = Nuclear_SolidCore_LH2
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.45
+
+    plumePosition = 0,0,0
+    plumeScale = 0.45
+  }
+  PLUME
+  {
+    name = Nuclear_SolidCore_LOX
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.4
+
+    plumePosition = 0,0,0
+    plumeScale = 0.4
+  }
+  @MODULE[ModuleEnginesRF],0
+  {
+      %runningEffectName = Nuclear_SolidCore_LH2
+  }
+  @MODULE[ModuleEnginesRF],1
+  {
+      %runningEffectName = Nuclear_SolidCore_LOX
+  }
+}

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-125-1.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-125-1.cfg
@@ -67,8 +67,8 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesRF
-    techLevel = 4
-    origTechLevel = 4
+    techLevel = 3
+    origTechLevel = 3
     engineType = N
     origMass = 2.3
     configuration = NTRLqdHydrogen
@@ -91,7 +91,7 @@
         ratio = 0.00000000001
       }
       IspSL = 0.5000
-      IspV = 1.0800
+      IspV = 1.1176
       throttle = 0
       ignitions = 0
       ullage = true

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-125-2.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-125-2.cfg
@@ -67,8 +67,8 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesRF
-    techLevel = 4
-    origTechLevel = 4
+    techLevel = 3
+    origTechLevel = 3
     engineType = N
     origMass = 1.8
     configuration = NTRLqdHydrogen
@@ -90,8 +90,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 0.8700
-      IspV = 0.8600
+      IspSL = 0.8947
+      IspV = 0.8824
       throttle = 0
       ignitions = 0
       ullage = true

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-125-2.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-125-2.cfg
@@ -1,0 +1,216 @@
+@PART[ntr-sc-125-2]:FOR[RealFuels_StockEngines]
+{
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 80
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 100.000000
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = EnrichedUranium
+      ratio = 0.00000000001
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.8
+    }
+  }
+
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[LOxAugmented]]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 180
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 93.75
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 6.25
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = EnrichedUranium
+      ratio = 0.00000000001
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 1.8
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 4
+    origTechLevel = 4
+    engineType = N
+    origMass = 1.8
+    configuration = NTRLqdHydrogen
+    modded = false
+    CONFIG
+    {
+      name = NTRLqdHydrogen
+      maxThrust = 80
+      heatProduction = 270.4343405
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.8700
+      IspV = 0.8600
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.8
+      }
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.8
+    }
+  }
+  
+  !MODULE[ModuleAlternator] {}
+  !MODULE[ModuleGenerator] {}
+  !RESOURCE[EnrichedUranium] {}
+  !RESOURCE[DepletedUranium] {}
+  MODULE
+  {
+    name = ModuleAlternator
+    OUTPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = -5.583333333333333E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 5.583333333333333E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 3.35
+    }
+  }
+  MODULE
+  {
+    name = ModuleGenerator
+    isAlwaysActive = true
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 1.675
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 5.583333333333333E-18
+    }
+    INPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = 5.583333333333333E-18
+    }
+  }
+  RESOURCE
+  {
+    name = EnrichedUranium
+    amount = 5.583333333333333
+    maxAmount = 5.583333333333333
+  }
+  RESOURCE
+  {
+    name = DepletedUranium
+    amount = 0
+    maxAmount = 5.583333333333333
+  }
+}
+
+@PART[ntr-sc-125-2]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+  PLUME
+  {
+    name = Nuclear_SolidCore_LH2
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.45
+
+    plumePosition = 0,0,0
+    plumeScale = 0.45
+  }
+  PLUME
+  {
+    name = Nuclear_SolidCore_LOX
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.4
+
+    plumePosition = 0,0,0
+    plumeScale = 0.4
+  }
+  @MODULE[ModuleEnginesRF],0
+  {
+      %runningEffectName = Nuclear_SolidCore_LH2
+  }
+  @MODULE[ModuleEnginesRF],1
+  {
+      %runningEffectName = Nuclear_SolidCore_LOX
+  }
+}

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-25-1.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-25-1.cfg
@@ -67,8 +67,8 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesRF
-    techLevel = 5
-    origTechLevel = 5
+    techLevel = 3
+    origTechLevel = 3
     engineType = N
     origMass = 10.5
     configuration = NTRLqdHydrogen
@@ -90,8 +90,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 0.7900
-      IspV = 1.0200
+      IspSL = 0.8421
+      IspV = 1.0882
       throttle = 0
       ignitions = 0
       ullage = true

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-25-1.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-25-1.cfg
@@ -1,0 +1,215 @@
+@PART[ntr-sc-25-1]:FOR[RealFuels_StockEngines]
+{
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 310
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 100.000000
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = EnrichedUranium
+      ratio = 0.00000000001
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 3.1
+    }
+  }
+
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[LOxAugmented]]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 775
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 93.75
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 6.25
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = EnrichedUranium
+      ratio = 0.00000000001
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 7.75
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 5
+    origTechLevel = 5
+    engineType = N
+    origMass = 10.5
+    configuration = NTRLqdHydrogen
+    modded = false
+    CONFIG
+    {
+      name = NTRLqdHydrogen
+      maxThrust = 310
+      heatProduction = 295.4173224
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.7900
+      IspV = 1.0200
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 3.1
+      }
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 3.1
+    }
+  }
+  !MODULE[ModuleAlternator] {}
+  !MODULE[ModuleGenerator] {}
+  !RESOURCE[EnrichedUranium] {}
+  !RESOURCE[DepletedUranium] {}
+  MODULE
+  {
+    name = ModuleAlternator
+    OUTPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = -25.833333333333332E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 25.833333333333332E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 15.5
+    }
+  }
+  MODULE
+  {
+    name = ModuleGenerator
+    isAlwaysActive = true
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 7.75
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 25.833333333333332E-18
+    }
+    INPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = 25.833333333333332E-18
+    }
+  }
+  RESOURCE
+  {
+    name = EnrichedUranium
+    amount = 25.833333333333332
+    maxAmount = 25.833333333333332
+  }
+  RESOURCE
+  {
+    name = DepletedUranium
+    amount = 0
+    maxAmount = 25.833333333333332
+  }
+}
+
+@PART[ntr-sc-25-1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+  PLUME
+  {
+    name = Nuclear_SolidCore_LH2
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.45
+
+    plumePosition = 0,0,0
+    plumeScale = 0.45
+  }
+  PLUME
+  {
+    name = Nuclear_SolidCore_LOX
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.4
+
+    plumePosition = 0,0,0
+    plumeScale = 0.4
+  }
+  @MODULE[ModuleEnginesRF],0
+  {
+      %runningEffectName = Nuclear_SolidCore_LH2
+  }
+  @MODULE[ModuleEnginesRF],1
+  {
+      %runningEffectName = Nuclear_SolidCore_LOX
+  }
+}

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-375-1.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-375-1.cfg
@@ -67,8 +67,8 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesRF
-    techLevel = 6
-    origTechLevel = 6
+    techLevel = 3
+    origTechLevel = 3
     engineType = N
     origMass = 25
     configuration = NTRLqdHydrogen
@@ -90,8 +90,8 @@
         name = EnrichedUranium
         ratio = 0.00000000001
       }
-      IspSL = 0.7900
-      IspV = 1.0200
+      IspSL = 2.1053
+      IspV = 1.0294
       throttle = 0
       ignitions = 0
       ullage = true

--- a/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-375-1.cfg
+++ b/GameData/RealFuels-Stock/KerbalAtomics/ntr-sc-375-1.cfg
@@ -1,0 +1,234 @@
+@PART[ntr-sc-375-1]:FOR[RealFuels_StockEngines]
+{
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 1450
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 100.000000
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = EnrichedUranium
+      ratio = 0.00000000001
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 14.5
+    }
+  }
+
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[LOxAugmented]]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 4350
+    !PROPELLANT[LqdHydrogen] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 93.75
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 6.25
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = EnrichedUranium
+      ratio = 0.00000000001
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 43.5
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 6
+    origTechLevel = 6
+    engineType = N
+    origMass = 25
+    configuration = NTRLqdHydrogen
+    modded = false
+    CONFIG
+    {
+      name = NTRLqdHydrogen
+      maxThrust = 1450
+      heatProduction = 1542.124783
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 100
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = EnrichedUranium
+        ratio = 0.00000000001
+      }
+      IspSL = 0.7900
+      IspV = 1.0200
+      throttle = 0
+      ignitions = 0
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 14.5
+      }
+    }
+    ignitions = -1
+    ullage = true
+    pressureFed = false
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 14.5
+    }
+  }
+  !MODULE[ModuleAlternator] {}
+  !MODULE[ModuleGenerator] {}
+  !RESOURCE[EnrichedUranium] {}
+  !RESOURCE[DepletedUranium] {}
+  MODULE
+  {
+    name = ModuleAlternator
+    OUTPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = -25.833333333333332E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 25.833333333333332E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 15.5
+    }
+  }
+  MODULE
+  {
+    name = ModuleAlternator
+    OUTPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = -120.83333333333333E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 120.83333333333333E-18
+    }
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 72.5
+    }
+  }
+  MODULE
+  {
+    name = ModuleGenerator
+    isAlwaysActive = true
+    OUTPUT_RESOURCE
+    {
+      name = ElectricCharge
+      rate = 36.25
+    }
+    OUTPUT_RESOURCE
+    {
+      name = DepletedUranium
+      rate = 120.83333333333333E-18
+    }
+    INPUT_RESOURCE
+    {
+      name = EnrichedUranium
+      rate = 120.83333333333333E-18
+    }
+  }
+  RESOURCE
+  {
+    name = EnrichedUranium
+    amount = 120.83333333333333
+    maxAmount = 120.83333333333333
+  }
+  RESOURCE
+  {
+    name = DepletedUranium
+    amount = 0
+    maxAmount = 120.83333333333333
+  }
+}
+
+@PART[ntr-sc-375-1]:FOR[RealPlume]:NEEDS[SmokeScreen]
+{
+  PLUME
+  {
+    name = Nuclear_SolidCore_LH2
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.45
+
+    plumePosition = 0,0,0
+    plumeScale = 0.45
+  }
+  PLUME
+  {
+    name = Nuclear_SolidCore_LOX
+    transformName = thrustTransform
+    localRotation = 0,0,0
+    localPosition = 0,0,0
+
+    energy = 1
+    speed = 1
+    emissionMult = 1
+
+    corePosition = 0,0,0
+    coreScale = 0.4
+
+    plumePosition = 0,0,0
+    plumeScale = 0.4
+  }
+  @MODULE[ModuleEnginesRF],0
+  {
+      %runningEffectName = Nuclear_SolidCore_LH2
+  }
+  @MODULE[ModuleEnginesRF],1
+  {
+      %runningEffectName = Nuclear_SolidCore_LOX
+  }
+}


### PR DESCRIPTION
NB: I left the stats of the engines as they were because of two main reasons.
- Nertea's mods are, in general, fairly well-balanced.
- I don't think the RFStockalike utility was built with open-cycle gas core NTRs and nuclear aerospikes in mind. Since I'm using that to generate accurate mass and heat production figures for the engines, I don't think they would make sense.

As such, the TWRs and/or heat production on some of the more powerful engines may be unbalanced.

The trimodal NTRs also only support LH2, and the LOX injection mode doesn't have a corresponding `ModuleEngineConfigs`. The others have had methane and ammonia configs added.

Resolves #12.